### PR TITLE
Handle PDF page count and reliable extraction

### DIFF
--- a/chatbot-backend/src/routes/chat.py
+++ b/chatbot-backend/src/routes/chat.py
@@ -3,37 +3,41 @@ import google.generativeai as genai
 import os
 import PyPDF2
 from io import BytesIO
-from dotenv import load_dotenv; load_dotenv()
+from dotenv import load_dotenv
 from uuid import uuid4
 
+load_dotenv()
 key = os.getenv("GEMINI_API_KEY")
 if not key:
     raise RuntimeError("GEMINI_API_KEY not set")
 genai.configure(api_key=key)
-
-
-chat_bp = Blueprint('chat', __name__)
-
-# Configure Gemini API
-genai.configure(api_key=os.getenv('GEMINI_API_KEY'))
-model = genai.GenerativeModel('gemini-2.5-flash', system_instruction=(
+model = genai.GenerativeModel(
+    'gemini-2.5-flash',
+    system_instruction=(
         "You are a professional chatbot. Always answer in clean Markdown with:\n"
         "- short title line\n- bullet points\n- bold keywords\n"
         "- tables when comparing items\n- code blocks for code."
-    ))
+    ),
+)
+
+chat_bp = Blueprint('chat', __name__)
 
 # Hold PDF text by id (simple in-memory cache for this assignment)
 PDF_STORE = {}  # { pdf_id: "full text ..." }
 
 def extract_pdf_text(file_storage):
-    reader = PyPDF2.PdfReader(file_storage.stream)
+    """Extract text and page count from an uploaded PDF file."""
+    pdf_bytes = file_storage.read()
+    reader = PyPDF2.PdfReader(BytesIO(pdf_bytes))
+
     parts = []
     for p in reader.pages:
         try:
             parts.append(p.extract_text() or "")
         except Exception:
             parts.append("")
-    return "\n\n".join(parts).strip()
+    text = "\n\n".join(parts).strip()
+    return text, len(reader.pages)
 
 @chat_bp.route("/upload-pdf", methods=["POST"])
 def upload_pdf():
@@ -41,7 +45,7 @@ def upload_pdf():
     if not f:
         return jsonify({"error": "No file uploaded"}), 400
 
-    text = extract_pdf_text(f)
+    text, pages = extract_pdf_text(f)
     pdf_id = str(uuid4())
     PDF_STORE[pdf_id] = text
 
@@ -49,6 +53,7 @@ def upload_pdf():
     return jsonify({
         "message": "PDF uploaded successfully",
         "pdf_id": pdf_id,
+        "pages": pages,
         "preview": preview
     })
 


### PR DESCRIPTION
## Summary
- read uploaded PDF bytes and extract text with PyPDF2
- return page count along with preview when uploading PDFs
- remove redundant Gemini configuration and centralize API key loading

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689aa2603c6c8321bd5fbd42cab3f265