### PR TITLE
Handle PDF page count and reliable extraction

### DIFF
--- a/chatbot-backend/requirements.txt
+++ b/chatbot-backend/requirements.txt
@@ -32,6 +32,7 @@ pydantic==2.11.7
 pydantic_core==2.33.2
 pyparsing==3.2.3
 PyPDF2==3.0.1
+pdfminer.six==20240706
 requests==2.32.4
 rsa==4.9.1
 SQLAlchemy==2.0.41


### PR DESCRIPTION
## Summary
- fall back to pdfminer when PyPDF2 cannot read a PDF
- return an error if no extractable text is found in an uploaded PDF
- guard chat route against missing or empty PDF context

## Testing
- `pip install -r chatbot-backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689aa2603c6c8321bd5fbd42cab3f265